### PR TITLE
修复在操作SPropertyGrid控件时，通过下拉列表设置属性后导致程序崩溃的问题

### DIFF
--- a/propgrid/propitem/SPropertyItem-Option.cpp
+++ b/propgrid/propitem/SPropertyItem-Option.cpp
@@ -62,7 +62,7 @@ namespace SOUI
         {
             SASSERT(!m_pCombobox);
             m_pCombobox = new TplPropEmbedWnd<SPropCombobox>(this);
-            wchar_t szXml[]=L"<combobox dropDown=\"1\" colorBkgnd=\"#ffffff\" focusable=\"0\">\
+            wchar_t szXml[]=L"<combobox dropDown=\"1\" colorBkgnd=\"#ffffff\" drawFocusRect=\"0\">\
                 <liststyle colorBorder=\"#000000\" margin-x=\"1\" margin-y=\"1\" colorText=\"#000000\" colorSelText=\"#FFFFFF\" colorItemBkgnd=\"#FFFFFF\" colorItemSelBkgnd=\"#000088\"/>\
                 </combobox>";
             pugi::xml_document xmlDoc;


### PR DESCRIPTION
修复在操作SPropertyGrid控件时，通过下拉列表设置属性后导致程序崩溃的问题